### PR TITLE
Update Ticker.kt

### DIFF
--- a/cache-kmp/src/commonMain/kotlin/com/dropbox/kmp/external/cache3/Ticker.kt
+++ b/cache-kmp/src/commonMain/kotlin/com/dropbox/kmp/external/cache3/Ticker.kt
@@ -26,4 +26,4 @@ typealias Ticker = () -> Long
 
 @OptIn(ExperimentalTime::class)
 internal val MonotonicTicker: Ticker = TimeSource.Monotonic.markNow()
-    .let { { it.elapsedNow().inWholeMilliseconds } }
+    .let { { it.elapsedNow().inWholeNanoseconds } }


### PR DESCRIPTION
Everywhere is counting with nanoseconds, but here was millis so cache ttl was 1000000 longer than expected .